### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -10,6 +10,7 @@
   ],
   "description" : "A Perl6 bindings for libLBFGS",
   "name" : "Algorithm::LBFGS",
+  "license" : "MIT",
   "perl" : "6.c",
   "provides" : {
     "Algorithm::LBFGS" : "lib/Algorithm/LBFGS.pm6",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license